### PR TITLE
Fix directory settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,7 @@
     "version": "1.0.3",
     "private": false,
     "description": "Run clippy and annotate the diff with errors and warnings",
-    "main": "lib/main.js",
-    "directories": {
-        "lib": "lib",
-        "test": "__tests__"
-    },
+    "main": "dist/index.js",
     "scripts": {
         "build": "ncc build src/main.ts --minify",
         "watch": "ncc build src/main.ts --watch --minify",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
         "target": "es6",
         "module": "commonjs",
         "allowJs": false,
-        "outDir": "./lib",
-        "rootDir": "./src",
+        "outDir": "dist",
         "strict": true,
         "noImplicitAny": false,
         "noUnusedLocals": true,
@@ -13,8 +12,7 @@
         "noFallthroughCasesInSwitch": true,
         "esModuleInterop": true
     },
-    "exclude": [
-        "node_modules",
-        "**/*.test.ts"
+    "include": [
+        "src"
     ]
 }


### PR DESCRIPTION
The `tsc` output is currently placed in `dist/index.js` but the `package.json` metadata differs. This fixes that. Also, rather than update the `directories` entry I just removed it since it doesn't do anything afaik.