### PR TITLE
Add support for manifest-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ jobs:
 
 ## Inputs
 
-| Name        | Required | Description                                                                                                                            | Type   | Default |
-| ------------| :------: | ---------------------------------------------------------------------------------------------------------------------------------------| ------ | --------|
-| `token`     | ✓        | GitHub secret token, usually a `${{ secrets.GITHUB_TOKEN }}`                                                                           | string |         |
-| `toolchain` |          | Rust toolchain to use; override or system default toolchain will be used if omitted                                                    | string |         |
-| `args`      |          | Arguments for the `cargo clippy` command                                                                                               | string |         |
-| `use-cross` |          | Use [`cross`](https://github.com/rust-embedded/cross) instead of `cargo`                                                               | bool   | false   |
-| `name`      |          | Name of the created GitHub check. If running this action multiple times, each run must have a unique name.                             | string | clippy  |
+| Name            | Required | Description                                                                                                                            | Type   | Default |
+| --------------- | :------: | ---------------------------------------------------------------------------------------------------------------------------------------| ------ | --------|
+| `token`         | ✓        | GitHub secret token, usually a `${{ secrets.GITHUB_TOKEN }}`                                                                           | string |         |
+| `toolchain`     |          | Rust toolchain to use; override or system default toolchain will be used if omitted                                                    | string |         |
+| `args`          |          | Arguments for the `cargo clippy` command                                                                                               | string |         |
+| `use-cross`     |          | Use [`cross`](https://github.com/rust-embedded/cross) instead of `cargo`                                                               | bool   | false   |
+| `name`          |          | Name of the created GitHub check. If running this action multiple times, each run must have a unique name.                             | string | clippy  |
+| `manifest-path` |          | Path of the Cargo.toml to check                                                                                                        | string |         |
 
 For extra details about the `toolchain`, `args` and `use-cross` inputs,
 see [`cargo` Action](https://github.com/actions-rs/cargo#inputs) documentation.

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
   name:
     description: Display name of the created GitHub check. Must be unique across several actions-rs/clippy-check invocations.
     default: clippy
+  manifest-path:
+    description: Path of the Cargo.toml to check
+    required: false
 
 runs:
   using: 'node12'

--- a/src/input.ts
+++ b/src/input.ts
@@ -13,6 +13,7 @@ export interface Input {
     args: string[],
     useCross: boolean,
     name: string,
+    manifestPath?: string,
 }
 
 export function get(): Input {
@@ -23,12 +24,14 @@ export function get(): Input {
     }
     const useCross = input.getInputBool('use-cross');
     const name = input.getInput('name');
+    const manifestPath = input.getInput('manifest-path');
 
     return {
         token: input.getInput('token', {required: true}),
         args: args,
         useCross: useCross,
         toolchain: toolchain || undefined,
-        name
+        name,
+        manifestPath: manifestPath || undefined
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,8 +51,12 @@ export async function run(actionInput: input.Input): Promise<void> {
     args.push('--message-format=json');
 
     args = args.concat(actionInput.args);
+    if (actionInput.manifestPath) {
+        args.concat(["--manifest-path", actionInput.manifestPath])
+    }
 
-    let runner = new CheckRunner();
+
+    let runner = new CheckRunner(actionInput.manifestPath);
     let clippyExitCode: number = 0;
     try {
         core.startGroup('Executing cargo clippy (JSON output)');


### PR DESCRIPTION
I believe this change will enable GitHub to correctly display the annotations in-line when using a `Cargo.toml` that is not in the project root.

* Adds `manifest-path:` option to the action
* When `manifest-path` is specified, inserts `--manifest-path <value>` into the clippy args list
* When `manifest-path` is specified, the generated annotations get the filename prefixed with the parent of the file specified via `manifest-path:`.

Addresses #28.

-----

Note: I have **not** (yet) built the `dist/index.js` (because I couldn't figure out how!).

I couldn't get it to build locally with the existing package.json due to inability to find `@actions-rs/core="0.1.3"` on npm. I was able to get it to build locally using a local clone, but then I couldn't get to actually work in my own github actions (presumably due to doing something wrong during the build).

I'm relatively inexperienced with npm, typescript, *and* github actions, so would appreciate any help getting this over the line. (Or an answer to #28)

