### PR TITLE
Limit the permissions of the API token in the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ name: Clippy check
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -42,6 +44,8 @@ name: Clippy check
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     steps:
       - uses: actions/checkout@v1
       - run: rustup component add clippy


### PR DESCRIPTION
This action only requires read/write access to the "checks"
scope. When the "permissions" object is present, all of the scopes
default to "none".