### PR TITLE
Use node-16 instead of node-12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ inputs:
     default: clippy
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Just saying, I'm completely unfamiliar with this codebase and to what this change might cause (regarding the code functionality), but this just follows along with [this github blog post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). You will also notice the error that every ci run gives with node 12, that is fixed with this pr.